### PR TITLE
feat: add 30 second delay

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -15,7 +15,7 @@ import {
 
 dotenv.config({ path: "../.env" });
 
-// call Hasura to find existing tickers in time series database,
+// function to call Hasura and find existing tickers in time series database,
 
 const existingTickerArray = (async () => {
   const result = await fetch(
@@ -31,34 +31,33 @@ const existingTickerArray = (async () => {
   return result;
 })();
 
-cron.schedule("*/30 * * * * *", () => {
-  job1()
-})
+// loop through each ticker in DB, call API every 30 seconds, update new TS data
 
-const job1 = () => {
-
-existingTickerArray.then((tickers) => {
-  let tickerStep = 0;
-
-  cron.schedule("*/30 * * * * *", () => {
-    console.log("now updating time series for:", tickers[tickerStep]);
-    getStockTimeSeriesAPI(tickers[tickerStep]).then((res) => {
-      fetch(
-        GRAPHQL_URL,
-        setQueryOptions(
-          UPSERT_TS_ON_EXISTING_TICKERS,
-          transformStockAPIResponse(res)
-        )
-      ).then(async (res) => {
-        const result = await res.json();
-        console.log("end result", result);
-      });
-
-      break when tickerStep = tickers.length 
-    });
-
-    tickerStep += 1;
+const upsertStockTimeSeriesOnDelay = () => {
+  existingTickerArray.then((tickers) => {
+    for (let i = 0; i < tickers.length; i++) {
+      setTimeout(() => {
+        console.log(new Date());
+        console.log("now updating time series for:", tickers[i]);
+        getStockTimeSeriesAPI(tickers[i]).then((res) => {
+          console.log(transformStockAPIResponse(res)[0]);
+          fetch(
+            GRAPHQL_URL,
+            setQueryOptions(
+              UPSERT_TS_ON_EXISTING_TICKERS,
+              transformStockAPIResponse(res)
+            )
+          ).then(async (res) => {
+            const result = await res.json();
+            console.log("end result", result);
+          });
+        });
+      }, 30000 * i);
+    }
   });
-});
+};
 
-}
+// run upsert function every day at midnight
+cron.schedule("0 0 * * *", () => {
+  upsertStockTimeSeriesOnDelay();
+});


### PR DESCRIPTION
- add logic to loop through each ticker in DB every 30 seconds, call API, write to Hasura
- wrap delay API call and upsert function in new cron schedule that runs every midnight
